### PR TITLE
test_images_negative: Fix URL of invalid server

### DIFF
--- a/tempest/api/compute/images/test_images_negative.py
+++ b/tempest/api/compute/images/test_images_negative.py
@@ -68,7 +68,7 @@ class ImagesNegativeTestJSON(base.BaseV2ComputeTest):
         resp = {}
         resp['status'] = None
         self.assertRaises(lib_exc.NotFound, self.create_image_from_server,
-                          '!@#$%^&*()', name=name, meta=meta)
+                          '!@$%^&*()', name=name, meta=meta)
 
     @test.attr(type=['negative'])
     @test.idempotent_id('ec176029-73dc-4037-8d72-2e4ff60cf538')


### PR DESCRIPTION
The requested server ID contains the hash tag, which makes the sent request url suffix of the form: `/v2/tenant-id/servers/!@#$%^&*()/action`, which includes a hash tag. The path of this url is `/v2/tenant-id/servers/!@` and the fragment identifier of this path is `$%^&*()/action`. This is not the right behavior and might lead to failures when a backend server parses the url correctly.
Removing the hash tag from the ID will fix this.