### PR TITLE
Successfully loaded k2k test parameters and refactored k2k token client

### DIFF
--- a/tempest/api/identity/v3/test_k2k_tokens.py
+++ b/tempest/api/identity/v3/test_k2k_tokens.py
@@ -1,0 +1,95 @@
+# Copyright 2015 OpenStack Foundation
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_utils import timeutils
+import six
+from tempest.api.identity import base
+from tempest import test
+
+from tempest.lib.services.identity.v3 import k2k_token_client
+
+import json  
+import os
+
+from tempest import config
+CONF = config.CONF
+
+class K2KTokensV3Test(base.BaseIdentityV3Test):
+
+    @test.idempotent_id('6f8e4436-fc96-4282-8122-e41df57197a9')
+    def test_get_unscoped_scoped_token(self):
+
+        idp_auth_url = 'http://localhost:5000/v3/auth/tokens'
+	username = CONF.auth.admin_username 	
+	password = CONF.auth.admin_password
+	project_name = CONF.auth.admin_project_name
+ 
+        k2k_client = k2k_token_client.K2KTokenClient(
+						auth_url=idp_auth_url, 
+						password=password)
+        idp_token, resp = k2k_client.get_token(auth_data=True,
+						project_name=project_name,
+						password=password,
+						username=username)
+
+        # check if idp_token is valid
+        self.assertNotEmpty(idp_token)
+        self.assertIsInstance(idp_token, six.string_types)
+        now = timeutils.utcnow()
+        expires_at = timeutils.normalize_time(
+            timeutils.parse_isotime(resp['expires_at']))
+        self.assertGreater(resp['expires_at'],
+                           resp['issued_at'])
+        self.assertGreater(expires_at, now)
+        subject_name = resp['user']['name']
+        self.assertEqual(subject_name, username)
+        self.assertEqual(resp['methods'][0], 'password')
+
+
+        assertion = k2k_client._get_ecp_assertion(token=idp_token)
+        unscoped_token = k2k_client.get_unscoped_token(assertion)
+        
+	# check if unscoped_token is valid
+        self.assertNotEmpty(unscoped_token)
+        self.assertIsInstance(unscoped_token, six.string_types)
+        now = timeutils.utcnow()
+        expires_at = timeutils.normalize_time(
+            timeutils.parse_isotime(resp['expires_at']))
+        self.assertGreater(resp['expires_at'],
+                           resp['issued_at'])
+        self.assertGreater(expires_at, now)
+        subject_name = resp['user']['name']
+        self.assertEqual(subject_name, username)
+        self.assertEqual(resp['methods'][0], 'password')
+	
+
+        sp_client = k2k_token_client.K2KTokenClient(auth_url=idp_auth_url, 
+							password=password)
+        scoped_token = sp_client.get_scoped_token(unscoped_token)
+
+	# check if scoped_token is valid
+        self.assertNotEmpty(scoped_token)
+        self.assertIsInstance(scoped_token, six.string_types)
+        now = timeutils.utcnow()
+        expires_at = timeutils.normalize_time(
+            timeutils.parse_isotime(resp['expires_at']))
+        self.assertGreater(resp['expires_at'],
+                           resp['issued_at'])
+        self.assertGreater(expires_at, now)
+        subject_name = resp['user']['name']
+        self.assertEqual(subject_name, username)
+        self.assertEqual(resp['methods'][0], 'password')
+
+

--- a/tempest/lib/common/http.py
+++ b/tempest/lib/common/http.py
@@ -49,7 +49,8 @@ class ClosingHttp(urllib3.poolmanager.PoolManager):
 
         # Follow up to 5 redirections. Don't raise an exception if
         # it's exceeded but return the HTTP 3XX response instead.
-        retry = urllib3.util.Retry(raise_on_redirect=False, redirect=5)
+	# set redirect=0 to prevent auto redirects
+        retry = urllib3.util.Retry(raise_on_redirect=False, redirect=0)
         r = super(ClosingHttp, self).request(method, url, retries=retry,
                                              *args, **new_kwargs)
         return Response(r), r.data

--- a/tempest/lib/common/rest_client.py
+++ b/tempest/lib/common/rest_client.py
@@ -248,7 +248,7 @@ class RestClient(object):
                 raise exceptions.InvalidHttpSuccessCode(details)
 
     def post(self, url, body, headers=None, extra_headers=False,
-             chunked=False):
+             chunked=False, saml=False):
         """Send a HTTP POST request using keystone auth
 
         :param str url: the relative url to send the post request to
@@ -263,9 +263,9 @@ class RestClient(object):
                  and the second the response body
         :rtype: tuple
         """
-        return self.request('POST', url, extra_headers, headers, body, chunked)
+        return self.request('POST', url, extra_headers, headers, body, chunked, saml)
 
-    def get(self, url, headers=None, extra_headers=False):
+    def get(self, url, headers=None, extra_headers=False, saml=None):
         """Send a HTTP GET request using keystone service catalog and auth
 
         :param str url: the relative url to send the post request to
@@ -278,7 +278,7 @@ class RestClient(object):
                  and the second the response body
         :rtype: tuple
         """
-        return self.request('GET', url, extra_headers, headers)
+        return self.request('GET', url, extra_headers, headers, saml)
 
     def delete(self, url, headers=None, body=None, extra_headers=False):
         """Send a HTTP DELETE request using keystone service catalog and auth
@@ -574,7 +574,7 @@ class RestClient(object):
                                      body=body, chunked=chunked)
 
     def request(self, method, url, extra_headers=False, headers=None,
-                body=None, chunked=False):
+                body=None, chunked=False, saml=None):
         """Send a HTTP request with keystone auth and using the catalog
 
         This method will send an HTTP request using keystone auth in the

--- a/tempest/lib/services/identity/v3/k2k_token_client.py
+++ b/tempest/lib/services/identity/v3/k2k_token_client.py
@@ -1,0 +1,141 @@
+# Copyright 2015 NEC Corporation.  All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_log import log as logging
+from oslo_serialization import jsonutils as json
+
+from tempest.lib.common import rest_client
+from tempest.lib import exceptions
+from tempest.lib.services.identity.v3 import token_client
+
+import six
+
+class K2KTokenClient(rest_client.RestClient):
+    def __init__(self, auth_url, password,
+                 disable_ssl_certificate_validation=None,
+                 ca_certs=None, trace_requests=None):
+	self.token_client = token_client.V3TokenClient(auth_url)
+
+	r, b = self.get_credentials(password)
+	self.sp_id = b['token']['service_providers'][0]['id']
+        self.ecp_url = str(b['token']['service_providers'][0]['sp_url'])
+        self.sp_auth_url = str(b['token']['service_providers'][0]['auth_url'])
+	#self.sp_ip contains the port number 5000
+    	self.sp_ip = str(b['token']['service_providers'][0]['sp_url'].split('/')[2])
+
+    
+    def get_token(self, **kwargs):
+        return self.token_client.get_token(**kwargs)
+
+    
+    def auth(self, **kwargs):
+        return self.token_client.auth(**kwargs)
+
+
+    def _get_ecp_assertion(self, token=None):
+	"""Obtains a token from the authentication service
+        :param sp_id: registered Service Provider id in Identity Provider
+        :param token: a token to perform K2K Federation.
+        Accepts one combinations of credentials.
+        - token, sp_id
+        Validation is left to the Service Provider side.
+        """
+        body = {
+            "auth": {
+                "identity": {
+                    "methods": [
+                        "token"
+                    ],
+                    "token": {
+                        "id": token
+                    }
+                },
+                "scope": {
+                    "service_provider": {
+                        "id": self.sp_id
+                    }
+                }
+            }
+        }
+	
+	self.body = body
+	url = 'http://localhost:5000/v3/auth/OS-FEDERATION/saml2/ecp'
+	endpoint_filter = {'version': (3, 0),
+                           'interface': 'public'}
+
+        headers = {'Accept': 'application/json'}
+
+        resp, body = self.token_client.post(url=url,
+                               body=json.dumps(body, sort_keys=True),
+                               headers=headers, saml='saml2')
+
+        self.expected_success(200, resp.status)
+        return six.text_type(body)
+
+
+    def get_unscoped_token(self, assertion):
+        """Send assertion to a Keystone SP and get an unscoped token"""
+	
+        r, b = self.token_client.post(
+            url=self.ecp_url,
+            headers={'Content-Type': 'application/vnd.paos+xml'},
+            body=assertion, saml='saml2')
+	
+	cookie = r['set-cookie'].split(';')[0]
+        headers={'Content-Type': 'application/vnd.paos+xml',
+                 'Cookie': cookie}
+        resp, body = self.token_client.get(url=self.sp_auth_url, headers=headers)
+        fed_token_id = resp['x-subject-token']
+        return fed_token_id
+
+
+    def get_scoped_token(self, _token):
+	"""Send an unscoped token and get a scoped token"""
+	
+	headers = {'x-auth-token': _token,
+                   'Content-Type': 'application/json'}
+
+	sp_auth_url = 'http://'+ self.sp_ip  +'/v3/auth/tokens'
+	#this is very ugly, needs to change. 
+	self.token_client.auth_url = sp_auth_url	
+	r = self.auth(token=_token)
+        scoped_token_id = str(r['token']['user']['OS-FEDERATION']['groups'][0]['id'])
+	return scoped_token_id
+
+
+    def get_credentials(self, password):
+        """ Get a token with default scope containing the service
+	    provider's credentials""" 
+	body = {
+            "auth": {
+              "identity": {
+                "methods": ["password"
+                 ],
+                 "password": {
+                   "user": {
+                     "name": "admin",
+                     "domain": { "id": "default"
+                      },
+                     "password": password
+                  }
+                }
+              }
+            }
+          }
+
+        headers = {"Content-Type": "application/json"}
+        url = 'http://localhost:5000/v3/auth/tokens'
+        r, b = self.token_client.post(url=url, headers=headers, body=json.dumps(body))
+	return r, b
+

--- a/tempest/lib/services/identity/v3/token_client.py
+++ b/tempest/lib/services/identity/v3/token_client.py
@@ -122,7 +122,7 @@ class V3TokenClient(rest_client.RestClient):
         return rest_client.ResponseBody(resp, body)
 
     def request(self, method, url, extra_headers=False, headers=None,
-                body=None, chunked=False):
+                body=None, chunked=False, saml=None):
         """A simple HTTP request interface.
 
         Note: this overloads the `request` method from the parent class and
@@ -147,11 +147,18 @@ class V3TokenClient(rest_client.RestClient):
         if resp.status in [401, 403]:
             resp_body = json.loads(resp_body)
             raise exceptions.Unauthorized(resp_body['error']['message'])
-        elif resp.status not in [200, 201, 204]:
+	elif resp.status == 302 and saml:
+	    pass
+        elif resp.status not in [200, 201, 204] and not saml:
             raise exceptions.IdentityError(
                 'Unexpected status code {0}'.format(resp.status))
+	
+	if saml:
+	    return resp, resp_body
+	else:    
+	    return resp, json.loads(resp_body)
 
-        return resp, json.loads(resp_body)
+
 
     def get_token(self, **kwargs):
         """Returns (token id, token data) for supplied credentials"""


### PR DESCRIPTION
- test_token_client.py:
Used config file to load username, password, and project name. 
All other needed credentials were loaded in k2k_token_client.py

- k2k_token_client.py:
refactored it to inherit from RestClient. 
Loaded all service provider's needed info using a post request in get_credentials() 
Used auth() to obtain the token in get_unscoped_token() 
