### PR TITLE
Remove requirement on unittest2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,3 @@ stevedore>=1.20.0 # Apache-2.0
 PrettyTable>=0.7.1 # BSD
 urllib3>=1.21.1 # MIT
 debtcollector>=1.2.0 # Apache-2.0
-unittest2>=1.1.0 # BSD

--- a/tempest/lib/base.py
+++ b/tempest/lib/base.py
@@ -28,11 +28,7 @@ def _handle_skip_exception():
         stestr_min = pkg_resources.parse_version('2.5.0')
         new_stestr = (stestr_version >= stestr_min)
         import unittest
-        import unittest2
-        if sys.version_info >= (3, 5) and new_stestr:
-            testtools.TestCase.skipException = unittest.case.SkipTest
-        else:
-            testtools.TestCase.skipException = unittest2.case.SkipTest
+        testtools.TestCase.skipException = unittest.case.SkipTest
     except Exception:
         pass
 

--- a/tempest/test_discover/test_discover.py
+++ b/tempest/test_discover/test_discover.py
@@ -17,10 +17,7 @@ import sys
 
 from tempest.test_discover import plugins
 
-if sys.version_info >= (2, 7):
-    import unittest
-else:
-    import unittest2 as unittest
+import unittest
 
 
 def load_tests(loader, tests, pattern):

--- a/tempest/tests/test_test.py
+++ b/tempest/tests/test_test.py
@@ -16,6 +16,7 @@
 import os
 import sys
 from unittest import mock
+import unittest
 
 from oslo_config import cfg
 import testtools
@@ -32,12 +33,6 @@ from tempest.tests import base
 from tempest.tests import fake_config
 from tempest.tests.lib import fake_credentials
 from tempest.tests.lib.services import registry_fixture
-
-
-if sys.version_info >= (2, 7):
-    import unittest
-else:
-    import unittest2 as unittest
 
 
 class LoggingTestResult(testtools.TestResult):


### PR DESCRIPTION
unittest2 is a backport package, which isn't relevant after python 3.5

You now have an explicit requirement for `python_requires >= 3.6`, so this package is no longer relevant.